### PR TITLE
fix: set type of switch component

### DIFF
--- a/src/components/Modal/ModalFile.tsx
+++ b/src/components/Modal/ModalFile.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useContext } from "react";
+import { ComponentProps, ReactElement, useContext } from "react";
 import { useForm, Controller, Control } from "react-hook-form";
 
 import { X } from "phosphor-react";
@@ -15,7 +15,7 @@ interface HistoryFile {
   undersign: string;
 }
 
-const Switch = (props) => (
+const Switch = (props: ComponentProps<typeof Controller>) => (
 
   <Controller
     {...props}


### PR DESCRIPTION
Set type of switch component because typescript need to know what kind
of component it is.